### PR TITLE
Add staticcheck linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ lint:
 	test -z $$(gofmt -l .) || (echo "Code isn't gofmt'ed!" && exit 1)
 	go vet $$(go list ./... | grep -v /tmp)
 	gosec -quiet -fmt=golint -exclude-dir="tmp" ./...
+	staticcheck ./...
 	# pointerinterface ./...
 
 # Runs spellchecker on the code and comments
@@ -29,9 +30,10 @@ analyse:
 # Updates 3rd party packages and tools
 installpkgs:
 	go mod download
-	go install github.com/securego/gosec/v2/cmd/gosec@latest
 	go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-	go install code.larus.se/lmas/pointerinterface@latest
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+	# go install code.larus.se/lmas/pointerinterface@latest
 
 # Clean up built binary and other temporary files (ignores errors from rm)
 clean:

--- a/components/system_test.go
+++ b/components/system_test.go
@@ -58,11 +58,10 @@ func (ec errorReadCloser) Close() error {
 var errMockTrans = fmt.Errorf("mock error")
 
 type mockTrans struct {
-	status       int
-	body         string
-	err          error
-	errBody      error
-	errBodyClose error
+	status  int
+	body    string
+	err     error
+	errBody error
 }
 
 func newMockTransport() *mockTrans {
@@ -87,10 +86,6 @@ func (t *mockTrans) setBodyError() {
 	t.errBody = errMockTrans
 }
 
-func (t *mockTrans) setBodyCloseError() {
-	t.errBodyClose = errMockTrans
-}
-
 // RoundTrip method is required to fulfil the RoundTripper interface (as required by the DefaultClient).
 // It prevents the request from being sent over the network.
 func (t *mockTrans) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -103,7 +98,7 @@ func (t *mockTrans) RoundTrip(req *http.Request) (*http.Response, error) {
 		Body: errorReadCloser{
 			strings.NewReader(t.body),
 			t.errBody,
-			t.errBodyClose,
+			nil,
 		},
 		ContentLength: int64(len(t.body)),
 		Request:       req,

--- a/usecases/configuration.go
+++ b/usecases/configuration.go
@@ -57,7 +57,7 @@ type configFileIn struct {
 	Resources []json.RawMessage       `json:"unit_assets"`
 }
 
-var ErrNewConfig = errors.New("A new configuration file has been created. Please update it and restart the system")
+var ErrNewConfig = errors.New("new config file was created")
 
 func setupDefaultConfig(sys *components.System) (defaultConfig templateOut, err error) {
 	var assetTemplate components.UnitAsset

--- a/usecases/consumption_test.go
+++ b/usecases/consumption_test.go
@@ -57,7 +57,7 @@ var form forms.SignalA_v1a
 
 var errEmptyRespBody = errors.New("got empty response body")
 
-var errUnpack = errors.New("Problem unpacking response body")
+var errUnpack = errors.New("problem unpacking response body")
 
 func createTestBytes() []byte {
 	return []byte("{\n  \"value\": 0,\n  \"unit\": \"\",\n  \"timestamp\": \"0001-01-01T00:00:00Z\",\n  \"version\": \"SignalA_v1.0\"\n}")


### PR DESCRIPTION
I would like to propose using this new linter, it had some good complementary linter checks: https://staticcheck.dev/docs/checks/

As an example, the tool found the following warnings:
```
> staticcheck ./...
components/system_test.go:90:21: func (*mockTrans).setBodyCloseError is unused (U1000)
usecases/configuration.go:60:20: error strings should not be capitalized (ST1005)
usecases/consumption_test.go:60:17: error strings should not be capitalized (ST1005)
```

These were fixed in the second commit.