### PR TITLE
Add govulncheck tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ lint:
 	go vet $$(go list ./... | grep -v /tmp)
 	gosec -quiet -fmt=golint -exclude-dir="tmp" ./...
 	staticcheck ./...
+	govulncheck -test ./...
 	# pointerinterface ./...
 
 # Runs spellchecker on the code and comments
@@ -33,6 +34,7 @@ installpkgs:
 	go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
 	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install golang.org/x/vuln/cmd/govulncheck@latest
 	# go install code.larus.se/lmas/pointerinterface@latest
 
 # Clean up built binary and other temporary files (ignores errors from rm)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sdoque/mbaigo
 
-go 1.23.4
+go 1.24.4

--- a/usecases/utilities.go
+++ b/usecases/utilities.go
@@ -94,7 +94,7 @@ func Unpack(data []byte, contentType string) (forms.Form, error) {
 	// Look up the form type in the map
 	formType, exists := forms.FormTypeMap[formVersion]
 	if !exists {
-		return nil, fmt.Errorf("unsupported form version: " + formVersion)
+		return nil, fmt.Errorf("unsupported form version: %s", formVersion)
 	}
 
 	// Create a new instance of the form


### PR DESCRIPTION
https://go.dev/doc/tutorial/govulncheck#install-and-run-govulncheck
It found 6 vulnerabilities, which were fixed by upgrading the module to latest Go version, as seen now:
```
govulncheck -test ./...
No vulnerabilities found.
```
It also seems to have sped up the test run (when race detection is enabled)? Probably free improvements with new Go version.
A linter warning for a `fmt.Errorf()` was also fixed.

# Warning

After Go version upgrade, `staticcheck` would complain about:
```
module requires at least go1.24, but Staticcheck was built with go1.23.10 (compile)
```

Had to remove and recompile `staticcheck` with new go version (https://go.dev/doc/manage-install#installing-multiple):
```
rm ~/go/bin/staticcheck
go install golang.org/dl/go1.24.4@latest
go1.24.4 download
go install honnef.co/go/tools/cmd/staticcheck@latest
rm -r ~/sdk/    # removes dir created by the download command above
```